### PR TITLE
fix(deps): bump idna to 3.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ filelock==3.20.3
 fonttools==4.61.1
 fsspec==2026.2.0
 grpcio==1.76.0
-idna==3.11
+idna==3.15
 Jinja2==3.1.6
 joblib==1.5.3
 kiwisolver==1.4.9


### PR DESCRIPTION
## Summary
- Bump `idna` from 3.11 to 3.15 in `requirements.txt`.
- Addresses the Dependabot security advisory (#21): specially crafted inputs to `idna.encode()` can bypass the CVE-2024-3651 fix.
- Transitive dependency of `requests`; no code change required. Low risk.

## Test plan
- [ ] `pip install -r requirements.txt` resolves without conflict
- [ ] App launches and EXIF read/write flows still work
- [ ] Dependabot alert #21 closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)